### PR TITLE
Fix popover overflow on mobile screens

### DIFF
--- a/src/components/BreadcrumbSection/index.tsx
+++ b/src/components/BreadcrumbSection/index.tsx
@@ -88,7 +88,7 @@ const BreadcrumbSection: FC<Props> = ({
             id="whitepaper"
             open={!!dropDownEl}
             transformOrigin={{horizontal: 'center', vertical: 'top'}}
-            transformOffset={{horizontal: width > 414 ? 0 : 50, vertical: 12}}
+            transformOffset={{horizontal: width > 400 ? 0 : 50, vertical: 12}}
           >
             {items &&
               items.map((item) => {


### PR DESCRIPTION
<img width="581" alt="Screenshot 2021-10-10 at 12 33 17" src="https://user-images.githubusercontent.com/16071782/136690310-f5cbab8b-10b3-4de0-8ddf-8750e4665828.png">

414px width is actual a mobile screen breakpoint so in mobile screens with 414px width popover will overflow.

Changed to 400px which is not a screen