### PR TITLE
Set new sample values in validator deployment guide

### DIFF
--- a/src/containers/DeveloperTools/NodeDeployment/DeploymentGuideValidator/index.tsx
+++ b/src/containers/DeveloperTools/NodeDeployment/DeploymentGuideValidator/index.tsx
@@ -43,7 +43,7 @@ const DeploymentGuideValidator: FC = () => {
             dataType: 'string',
             description: 'Network standardized type of node (PRIMARY_VALIDATOR or CONFIRMATION_VALIDATOR)',
             param: 'node_type',
-            sampleValue: 'PRIMARY_VALIDATOR',
+            sampleValue: 'CONFIRMATION_VALIDATOR',
           },
           {
             dataType: 'string',
@@ -56,8 +56,7 @@ const DeploymentGuideValidator: FC = () => {
             description:
               'Record of all account balances at the moment in time that the validator was first set to "primary"',
             param: 'root_account_file',
-            sampleValue:
-              'https://gist.githubusercontent.com/buckyroberts/519b5cb82a0a5b5d4ae8a2175b722520/raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json',
+            sampleValue: 'http://52.52.160.149:80/media/root_account_file.json',
           },
           {
             dataType: 'string',


### PR DESCRIPTION
This PR is just for 2 minor things I've noticed whilst setting up a CV which gave me a bit of confusion. This PR can prevent duplicate questions like mine in Discord.

The default sample value is currently `PRIMARY_VALIDATOR`. This value will most likely result in people using this default value and thus setting up new PVs. (This is what I wanted to do first)
However, according to @hussu010  "Setting a new PV will mean you're trying to host your own version of TNBC chain." And I'm pretty sure, that most people don't actually want to host their own version, but just want to expand upon the current chain. Therefore changing the default value to `CONFIRMATION_VALIDATOR` seems more logical to me.

Furthermore, the `https://gist.githubusercontent.com/buckyroberts/519b5cb82a0a5b5d4ae8a2175b722520/raw/9237deb449e27cab93cb89ea3346ecdfc61fe9ea/0.json` default value for the root account file doesn't work as it will throw an exception related to expecting an integer, but receiving a double. The suggested `root_account_file.json` file is now from Bucky's PV.

If applicable, this is my account number:
4114626f5c783311cfe7a6b88b7bc4a9135c6b1310009dcca5cf36d2395f8814